### PR TITLE
pyandoc with citations, pdf, epub, and pandoc executable from path

### DIFF
--- a/pandoc/core.py
+++ b/pandoc/core.py
@@ -7,7 +7,7 @@ PANDOC_PATH = 'pandoc'
 
 def set_path(path):
     global PANDOC_PATH
-	PANDOC_PATH = path
+    PANDOC_PATH = path
 
 class Document(object):
     """A formatted document."""


### PR DESCRIPTION
I've re-forked [my previous changes](https://github.com/kennethreitz/pyandoc/pull/6) because I changed some files that I shouldn't have (sorry, @kennethreitz!).

The purpose of this fork is to implemented _Pandoc_'s citations and PDF output.
## Citations in Markdown

I wanted to use _Pandoc_ for parsing _Markdown_ files with _citations_.
Pandoc supports that by giving a _--bibliography=FILE_ command-line argument with a bibliography file (like _.bib_).
See the [Pandoc documentation](http://johnmacfarlane.net/pandoc/README.html#citations) for more details on that.

But _pyandoc_ did not support that. So I changed it.
- Added and _add_argument_ method to the _Document_ class where you can give any argument listed in the _Pandoc_ documentation.
  For example, want a Table of Contents? Do _add_argument("toc")_. 
- Added an _bib(bibfile)_ method. This method will check that the file given exists and will pass it to the arguments with the _bibliography=_ prefix.
- Same for _csl(cslfile)_ for specifing an _CSL_ file.
## PDF and EPUB output

I wanted to output PDF files with Pandoc, but _pyandoc_ outputs to the stdout, 
and PDFs are generated in Pandoc using LaTeX and therefore must be output to file.
So I wrote a new method in _pyandoc.Document_ called _to_file_. 
The method accepts an output filename (with an extention that Pandoc knows, such as _pdf_ or _epub_).
I tested it with PDF and EPUB but it should work for other formats as well. The method works with the
_bib_ and all the other stuff mentioned above.
## Pandoc executable path

The original project had the path to the _pandoc_ executable hardcoded, and you were supposed to change it after import.
But that didn't work for me (got an error - see [issue](https://github.com/kennethreitz/pyandoc/issues/5)).
So I changed the hardcoded path, it is in the file _core.py_ at the top. 
It is now simply _pandoc_ so you can either change it via _pyandoc.PANDOC_PATH_ or just
put _pandoc_ in your path. This solution should work for both Windows and Linux users, I think.
## Other details

I tested this on Windows 7 64-bit with _Pandoc_ 1.9.4.2 (running _citeproc-hs_ 0.3.4).

I'm using _pyandoc_ as an alternative HTML renderer for [Flask-FlatPages](http://packages.python.org/Flask-FlatPages/#flask_flatpages) 
to render blog posts written in _Markdown_ and containing academic citations - see the project [here](https://github.com/yoavram/yoavram.github.com/tree/source) and the module that uses _pyandoc_ to render HTML [here](https://github.com/yoavram/yoavram.github.com/blob/source/renderers.py).
