### PR TITLE
Make __init__.py work in python3

### DIFF
--- a/pandoc/__init__.py
+++ b/pandoc/__init__.py
@@ -1,1 +1,1 @@
-from core import *
+from .core import *


### PR DESCRIPTION
Adding the updated relative import style for py3 compatibility (`from .core import *`) /